### PR TITLE
evcc sponsoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </div>
 <h1 align="center">Heidel<span style="color:#646bafff">Bridge</span></h1>
 
-HeidelBridge is a firmware for ESP32 microcontrollers. It allows you to bring your [Heidelberg wallbox](https://www.heidelberg-wallbox.eu) into your WiFi network. This is done by turning your wallbox into a [Daheimladen](https://www.daheimladen.de/) compatible device. This way the wallbox can easily be integrated into home energy management systems like [evcc](https://github.com/evcc-io/evcc) (no sponsor token required!).
+HeidelBridge is a firmware for ESP32 microcontrollers. It allows you to bring your [Heidelberg wallbox](https://www.heidelberg-wallbox.eu) into your WiFi network. This is done by turning your wallbox into a [Daheimladen](https://www.daheimladen.de/) compatible device. This way the wallbox can easily be integrated into home energy management systems like [evcc](https://github.com/evcc-io/evcc).
 
 ![PlatformIO CI Build](https://github.com/BorisBrock/Heidelbridge/actions/workflows/build.yml/badge.svg)
 ![Flawfinder Code Analysis](https://github.com/BorisBrock/Heidelbridge/actions/workflows/flawfinder.yml/badge.svg)


### PR DESCRIPTION
Hi @BorisBrock, ich bin einer der evcc Entwickler. Der Nachsatz (inkl. Ausrufezeichen) fühlt sich für mich sehr falsch an. Ich geh mal davon aus, dass der primäre Zweck dieses Repos nicht ist, das Sponsortoken zu umgehen, sondern zusätzliche Anwendungsfälle zu erlauben.

Wir stecken 'ne Menge Entwicklungsarbeit in evcc und sind, wie du, auch große Freunde von offenem Code. Die Menge an Energie und Zeit, die wir aktuell in dieses Projekt stecken, funktioniert, nur dank Sponsoring durch Endnutzer.

Daher würde ich dich bitten, nicht damit zu werben, dass man durch deine Software für eine sonst sponsorpflichtige Wallbox kein Sponsoring mehr braucht.

Viele Grüße, Michael