### PR TITLE
Update WifiConnection.cpp

### DIFF
--- a/src/Components/WiFi/WifiConnection.cpp
+++ b/src/Components/WiFi/WifiConnection.cpp
@@ -39,6 +39,7 @@ namespace WifiConnection
 
         // Set host name
         WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE, INADDR_NONE);
+        WiFi.mode(WIFI_MODE_NULL);
         WiFi.setHostname("HeidelBridge");
 
         // Register WiFi events


### PR DESCRIPTION
Setting Hostname did not work in my setup with Fritzbox 5590. Did a bit of research and found that calling "WiFi.mode(WIFI_MODE_NULL);" might be necessary for setHostname to be sucessfull.

Worked for me.