### PR TITLE
Lilygo build flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,23 @@ HeidelBridge is a firmware for ESP32 microcontrollers. It allows you to bring yo
 
 # Required Hardware
 
-You only need two components for this project: an ESP32 microcontroller and a MAX485 module. Both are available in large quantities and at reasonable prices on the Internet. You will also need a breadboard and a few jumper wires. All in all, it shouldn't cost you more than 10€.
+You have two options for the hardware setup:
+
+## Option 1: ESP32 + External MAX485 Module
+You need two components: an ESP32 microcontroller and a MAX485 module. Both are available in large quantities and at reasonable prices on the Internet. You will also need a breadboard and a few jumper wires. All in all, it shouldn't cost you more than 10€.
 
 Parts list:
 - ESP32 microcontroller*
 - MAX485 breakout board
 - 6 jumper wires
 - A breadboard
+
+## Option 2: LilyGo T-Can485 Board
+Alternatively, you can use a LilyGo T-Can485 board which has the RS485 transceiver already built-in, eliminating the need for an external MAX485 module.
+
+Parts list:
+- LilyGo T-Can485 board (includes ESP32 + built-in RS485 transceiver)
+- 3 jumper wires (for connecting to the wallbox)
 
 This should be enough for quickly putting together a fully functioning prototype.
 Of course a well designed PCB would be much nicer, but this is still work in progress. Once the design is ready, the schematics will be available *right here*.

--- a/docs/SoftwareSetup.md
+++ b/docs/SoftwareSetup.md
@@ -51,8 +51,55 @@ Then follow these steps:
 
 - Start by cloning or downloading this repository.
 - Optional: change `board = ...` in platformio.ini to match the ESP32 board you are actually using.
+- Choose the appropriate build environment (see [Build Environments](#build-environments) below).
 - Compile the project.
 - Build the file system image via the PlatformIO command palette.
 - Now connect your ESP32 via USB.
 - Upload the file system image.
 - Upload the firmware.
+
+## Build Environments
+
+HeidelBridge supports multiple build environments to accommodate different hardware configurations:
+
+### Standard ESP32 + External RS485 Module (`heidelberg`)
+This is the default build environment for regular ESP32 development boards with an external RS485 module.
+
+**To compile:**
+```bash
+pio run -e heidelberg
+```
+
+**Pin configuration:**
+- GPIO18 → RS485 RO (Receiver Output)
+- GPIO19 → RS485 DI (Driver Input)  
+- GPIO21 → RS485 DE+RE
+
+### LilyGo T-Can485 Board (`lilygo`)
+This build environment is specifically designed for the LilyGo T-Can485 board, which has built-in RS485 capabilities and **does not require an external MAX485 module**.
+
+**To compile:**
+```bash
+pio run -e lilygo
+```
+
+**Pin configuration:**
+- GPIO21 → RS485 RO (Receiver Output)
+- GPIO22 → RS485 DI (Driver Input)
+- GPIO21 → RS485 DE+RE
+
+**Additional features:**
+- Automatic initialization of onboard RS485 transceivers
+- 5V power supply control
+- CAN bus support (hardware available but not used in current firmware)
+- **No external MAX485 module needed** - RS485 transceiver is built into the board
+
+For detailed wiring information and hardware setup for the LilyGo T-Can485 board, please refer to the [discussion thread](https://github.com/BorisBrock/HeidelBridge/discussions/4).
+
+### Dummy Wallbox (`dummy`)
+This build environment creates a simulation mode for testing without actual wallbox hardware.
+
+**To compile:**
+```bash
+pio run -e dummy
+```

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,10 +12,10 @@
 default_envs = heidelberg
 
 [env]
-platform = espressif32@^6.8.1
-board = esp32doit-devkit-v1
+platform = espressif32
+board = esp32dev
 upload_protocol = esptool
-upload_port = /dev/ttyUSB*
+upload_port = COM4
 framework = arduino
 board_build.partitions = partitions.csv
 monitor_speed = 115200
@@ -41,3 +41,9 @@ build_flags =
   -O2
   -D DUMMY_WALLBOX
   -D LOGGING_LEVEL_DEBUG
+
+[env:lilygo]
+build_flags = 
+  -O2
+  -D LILYGO_BOARD
+  -D LOGGING_LEVEL_ERROR

--- a/src/Components/Modbus/ModbusRTU.cpp
+++ b/src/Components/Modbus/ModbusRTU.cpp
@@ -25,6 +25,20 @@ void ModbusRTU::Init()
     gMutex = xSemaphoreCreateMutex();
 
     // Init serial conneted to the RTU Modbus
+
+#ifdef LILYGO_BOARD
+    //config for Lilygo ESP32 RS485 board
+    pinMode(RS485_EN_PIN, OUTPUT);
+    digitalWrite(RS485_EN_PIN, HIGH);
+
+    pinMode(RS485_SE_PIN, OUTPUT);
+    digitalWrite(RS485_SE_PIN, HIGH);
+
+    pinMode(PIN_5V_EN, OUTPUT);
+    digitalWrite(PIN_5V_EN, HIGH);
+    // end config for Lilygo ESP32 RS485 board
+#endif
+
     Logger::Info("Starting RS485 hardware serial");
     RTUutils::prepareHardwareSerial(gRs485Serial);
     gRs485Serial.begin(

--- a/src/Configuration/Pins.h
+++ b/src/Configuration/Pins.h
@@ -2,6 +2,17 @@
 
 namespace Pins
 {
+#ifdef LILYGO_BOARD
+    // Config for the Lilygo T-Can485 Board
+    // Pin connections:
+    // ESP32 GPIO21 -> MAXRS485 RO (Receiver Output)
+    // ESP32 GPIO22 -> MAXRS485 DI (Driver Input)
+    // ESP32 GPIO21 -> MAXRS485 DE+RE
+    constexpr uint8_t PinRX = GPIO_NUM_21;
+    constexpr uint8_t PinTX = GPIO_NUM_22;
+    constexpr uint8_t PinRTS = GPIO_NUM_21;
+#else
+    // Config for regular ESP32 boards + external RS485 module
     // Pin connections:
     // ESP32 GPIO18 -> MAXRS485 RO (Receiver Output)
     // ESP32 GPIO19 -> MAXRS485 DI (Driver Input)
@@ -9,4 +20,25 @@ namespace Pins
     constexpr uint8_t PinRX = GPIO_NUM_18;
     constexpr uint8_t PinTX = GPIO_NUM_19;
     constexpr uint8_t PinRTS = GPIO_NUM_21;
+#endif
 };
+
+#ifdef LILYGO_BOARD
+#define PIN_5V_EN 16
+
+#define CAN_TX_PIN 26
+#define CAN_RX_PIN 27
+#define CAN_SE_PIN 23
+
+#define RS485_EN_PIN 17 // 17 /RE
+#define RS485_TX_PIN 22 // 21
+#define RS485_RX_PIN 21 // 22
+#define RS485_SE_PIN 19 // 22 /SHDN
+
+#define SD_MISO_PIN 2
+#define SD_MOSI_PIN 15
+#define SD_SCLK_PIN 14
+#define SD_CS_PIN 13
+
+#define WS2812_PIN 4
+#endif


### PR DESCRIPTION
 - Add lilygo build environment to platformio.ini
- Configure LilyGo-specific pins in Pins.h with RS485 transceiver pins
- Add LilyGo board initialization in ModbusRTU.cpp with GPIO setup
- Update README.md to include LilyGo T-Can485 as hardware option
- Add comprehensive documentation in SoftwareSetup.md for LilyGo build environment
