### PR TITLE
Fixed HomeAssistant integration

### DIFF
--- a/src/Components/MQTT/MQTTManager.cpp
+++ b/src/Components/MQTT/MQTTManager.cpp
@@ -24,7 +24,7 @@ namespace MQTTManager
     IWallbox *gWallbox = nullptr;
     uint8_t gCurValueIndex = 0;
     char TopicBuffer[128];
-    char PayloadBuffer[512];
+    char PayloadBuffer[1024];
     PrefixedString gMqttTopic(128);
 
     constexpr uint16_t NumMqttPublishedValues = 10;
@@ -67,55 +67,108 @@ namespace MQTTManager
         // Publish Home Assistant MQTT discovery messages
         PublishHomeAssistantDiscoveryTopic(
             "homeassistant/binary_sensor/%/is_vehicle_connected/config",
-            R"({"name":"Vehicle connected","device_class":"plug","state_topic":"%/is_vehicle_connected","payload_on":"1","payload_off":"0","unique_id":"%_is_vehicle_connected","object_id":"is_vehicle_connected","device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
-
-        PublishHomeAssistantDiscoveryTopic(
-            "homeassistant/binary_sensor/%/is_vehicle_charging/config",
-            R"({"name":"Vehicle charging","device_class":"battery_charging","state_topic":"%/is_vehicle_charging","payload_on":"1","payload_off":"0","unique_id":"%_is_vehicle_charging","object_id":"is_vehicle_charging","device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
-
-        PublishHomeAssistantDiscoveryTopic(
-            "homeassistant/sensor/%/charging_power/config",
-            R"({"name":"Charging power","device_class":"power","state_topic":"%/charging_power","unique_id":"%_charging_power","object_id":"charging_power","unit_of_measurement":"W","device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
-
-        PublishHomeAssistantDiscoveryTopic(
-            "homeassistant/sensor/%/charging_current/config",
-            R"({"name":"Charging current","device_class":"current","state_topic":"%/charging_current/phase1","unique_id":"%_charging_current","object_id":"charging_current","unit_of_measurement":"A","device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
-
-        PublishHomeAssistantDiscoveryTopic(
-            "homeassistant/sensor/%/charging_current_limit/config",
-            R"({"name":"Charging current limit","device_class":"current","state_topic":"%/charging_current_limit","unique_id":"%_charging_current_limit","object_id":"charging_current_limit","unit_of_measurement":"A","device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
-
-        PublishHomeAssistantDiscoveryTopic(
-            "homeassistant/sensor/%/energy_meter/config",
-            R"({"name":"Energy meter","device_class":"energy","state_topic":"%/energy_meter","state_class":"total_increasing","unique_id":"%_energy_meter","object_id":"energy_meter","unit_of_measurement":"kWh","device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
-
-        PublishHomeAssistantDiscoveryTopic(
-            "homeassistant/sensor/%/temperature/config",
-            R"({"name":"Temperature","device_class":"temperature","state_topic":"%/temperature","unique_id":"%_temperature","object_id":"temperature","unit_of_measurement":"°C","device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
-
-        PublishHomeAssistantDiscoveryTopic(
-            "homeassistant/switch/%/enable_charging/config",
             R"({
-                "name": "Enable Charging",
-                "state_topic": "%/enable_charging",
-                "command_topic": "%/control/enable_charging",
-                "unique_id": "%_enable_charging_switch",
-                "object_id": "enable_charging",
-                "payload_on": "ON",
-                "payload_off": "OFF",
+                "name":"Vehicle connected",
+                "device_class":"plug",
+                "state_topic":"%/is_vehicle_connected",
+                "payload_on":"1",
+                "payload_off":"0",
+                "unique_id":"%_is_vehicle_connected",
+                "object_id":"%_is_vehicle_connected",
                 "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
 
         PublishHomeAssistantDiscoveryTopic(
-            "homeassistant/number/%/charging_current_limit/config",
+            "homeassistant/binary_sensor/%/is_vehicle_charging/config",
             R"({
-                "name": "Charging Current Limit",
-                "command_topic": "%/control/charging_current_limit",
-                "state_topic": "%/charging_current_limit",
-                "min": 6,
-                "max": 16,
-                "step": 1,
-                "unit_of_measurement": "A",
-                "uniq_id": "heidelbridge_charging_current_limit",
+                "name":"Vehicle charging",
+                "device_class":"battery_charging",
+                "state_topic":"%/is_vehicle_charging",
+                "payload_on":"1",
+                "payload_off":"0",
+                "unique_id":"%_is_vehicle_charging",
+                "object_id":"%_is_vehicle_charging",
+                "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
+
+        PublishHomeAssistantDiscoveryTopic(
+            "homeassistant/sensor/%/charging_power/config",
+            R"({
+                "name":"Charging power",
+                "device_class":"power",
+                "state_topic":"%/charging_power",
+                "unique_id":"%_charging_power",
+                "object_id":"%_charging_power",
+                "unit_of_measurement":"W",
+                "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
+
+        PublishHomeAssistantDiscoveryTopic(
+            "homeassistant/sensor/%/charging_current/config",
+            R"({
+                "name":"Charging current",
+                "device_class":"current",
+                "state_topic":"%/charging_current/phase1",
+                "unique_id":"%_charging_current",
+                "object_id":"%_charging_current",
+                "unit_of_measurement":"A",
+                "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
+
+        PublishHomeAssistantDiscoveryTopic(
+            "homeassistant/sensor/%/charging_current_limit/config",
+            R"({
+                "name":"Charging current limit",
+                "device_class":"current",
+                "state_topic":"%/charging_current_limit",
+                "unique_id":"%_charging_current_limit",
+                "object_id":"%_charging_current_limit",
+                "unit_of_measurement":"A",
+                "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
+
+        PublishHomeAssistantDiscoveryTopic(
+            "homeassistant/sensor/%/energy_meter/config",
+            R"({
+                "name":"Energy meter",
+                "device_class":"energy",
+                "state_topic":"%/energy_meter",
+                "state_class":"total_increasing",
+                "unique_id":"%_energy_meter",
+                "object_id":"%_energy_meter",
+                "unit_of_measurement":"kWh",
+                "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
+
+        PublishHomeAssistantDiscoveryTopic(
+            "homeassistant/sensor/%/temperature/config",
+            R"({
+                "name":"Temperature",
+                "device_class":"temperature",
+                "state_topic":"%/temperature",
+                "unique_id":"%_temperature",
+                "object_id":"%_temperature",
+                "unit_of_measurement":"°C",
+                "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
+
+        PublishHomeAssistantDiscoveryTopic(
+            "homeassistant/switch/%/control_enable_charging/config",
+            R"({
+                "name":"Enable Charging",
+                "state_topic":"%/enable_charging",
+                "command_topic":"%/control/enable_charging",
+                "unique_id":"%control_enable_charging",
+                "object_id":"%control_enable_charging",
+                "payload_on":"ON",
+                "payload_off":"OFF",
+                "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
+
+        PublishHomeAssistantDiscoveryTopic(
+            "homeassistant/number/%/control_charging_current_limit/config",
+            R"({
+                "name":"Charging Current Limit",
+                "command_topic":"%/control/charging_current_limit",
+                "state_topic":"%/charging_current_limit",
+                "min":6,
+                "max":16,
+                "step":1,
+                "unit_of_measurement":"A",
+                "unique_id":"%_control_charging_current_limit",
+                "object_id":"%_control_charging_current_limit",
                 "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
     }
 

--- a/src/Components/MQTT/MQTTManager.cpp
+++ b/src/Components/MQTT/MQTTManager.cpp
@@ -103,11 +103,20 @@ namespace MQTTManager
                 "object_id": "enable_charging",
                 "payload_on": "ON",
                 "payload_off": "OFF",
-                 "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
+                "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
 
         PublishHomeAssistantDiscoveryTopic(
             "homeassistant/number/%/charging_current_limit/config",
-            R"({"name": "Charging Current Limit", "command_topic": "%/control/charging_current_limit", "state_topic": "%/status/charging_current_limit", "min": 6, "max": 16, "step": 1, "unit_of_measurement": "A", "uniq_id": "heidelbridge_charging_current_limit", "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
+            R"({
+                "name": "Charging Current Limit",
+                "command_topic": "%/control/charging_current_limit",
+                "state_topic": "%/charging_current_limit",
+                "min": 6,
+                "max": 16,
+                "step": 1,
+                "unit_of_measurement": "A",
+                "uniq_id": "heidelbridge_charging_current_limit",
+                "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
     }
 
     // Publishes various MQTT status messages based on the current value index.


### PR DESCRIPTION
I had issues with my wallbox in HomeAssistant and found that messages where not delivered.
This was because my HeidelBridge name was so long it made certain messages exceed 512 characters.
I was able to fix this and also made some other improvements to the auto discovery for HomeAssistant.
I tested it with my wallbox and now all works as expected.