### PR TITLE
Enable/Disable Standby of HeidelbergWallbox

### DIFF
--- a/src/Components/MQTT/MQTTManager.cpp
+++ b/src/Components/MQTT/MQTTManager.cpp
@@ -157,6 +157,19 @@ namespace MQTTManager
                 "payload_off":"OFF",
                 "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
 
+        // Standby Switch (neu)
+        PublishHomeAssistantDiscoveryTopic(
+            "homeassistant/switch/%/control_standby/config",
+            R"({
+                "name":"Standby Mode",
+                "state_topic":"%/standby_enabled",
+                "command_topic":"%/control/standby",
+                "unique_id":"%_control_standby",
+                "default_entity_id":"%_control_standby",
+                "payload_on":"ON",
+                "payload_off":"OFF",
+                "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
+
         PublishHomeAssistantDiscoveryTopic(
             "homeassistant/number/%/control_charging_current_limit/config",
             R"({
@@ -256,6 +269,9 @@ namespace MQTTManager
 
             gMqttClient.publish(gMqttTopic.SetString("/enable_charging"), 0, true,
                                 gWallbox->IsChargingEnabled() ? "ON" : "OFF");
+
+            gMqttClient.publish(gMqttTopic.SetString("/standby_enabled"), 0, true,
+                                gWallbox->IsStandbyEnabled() ? "ON" : "OFF");
         }
     }
 
@@ -267,6 +283,7 @@ namespace MQTTManager
         // Subscribe to control topics
         gMqttClient.subscribe(gMqttTopic.SetString("/control/charging_current_limit"), 2);
         gMqttClient.subscribe(gMqttTopic.SetString("/control/enable_charging"), 2);
+        gMqttClient.subscribe(gMqttTopic.SetString("/control/standby"), 2);
 
         // Publish version information
         String versionString = String(Version::Major) + "." + String(Version::Minor) + "." + String(Version::Patch);
@@ -301,6 +318,14 @@ namespace MQTTManager
             Logger::Trace("Received MQTT control command: enable_charging = %s", cmd.c_str());
             bool enableCharging = cmd.equalsIgnoreCase("ON");
             gWallbox->SetChargingEnabled(enableCharging);
+        }
+        else if (strcmp(gMqttTopic.SetString("/control/standby"), topic) == 0)
+        {
+            String cmd(payload, len);
+            cmd.trim();
+            Logger::Trace("Received MQTT control command: standby = %s", cmd.c_str());
+            bool enableStandby = cmd.equalsIgnoreCase("ON");
+            gWallbox->SetStandbyEnabled(enableStandby);
         }
     }
 

--- a/src/Components/MQTT/MQTTManager.cpp
+++ b/src/Components/MQTT/MQTTManager.cpp
@@ -271,7 +271,7 @@ namespace MQTTManager
                                 gWallbox->IsChargingEnabled() ? "ON" : "OFF");
 
             gMqttClient.publish(gMqttTopic.SetString("/standby_enabled"), 0, true,
-                                gWallbox->IsStandbyEnabled() ? "ON" : "OFF");
+                                gWallbox->GetStandbyEnabled() ? "ON" : "OFF");
         }
     }
 

--- a/src/Components/MQTT/MQTTManager.cpp
+++ b/src/Components/MQTT/MQTTManager.cpp
@@ -157,7 +157,6 @@ namespace MQTTManager
                 "payload_off":"OFF",
                 "device":{"identifiers":["%"],"name":"%","model":"EnergyControl","manufacturer":"Heidelberg"}})");
 
-        // Standby Switch (neu)
         PublishHomeAssistantDiscoveryTopic(
             "homeassistant/switch/%/control_standby/config",
             R"({

--- a/src/Components/Wallbox/DummyWallbox.cpp
+++ b/src/Components/Wallbox/DummyWallbox.cpp
@@ -75,7 +75,6 @@ bool DummyWallbox::IsChargingEnabled()
     return mChargingEnabled;
 }
 
-//New Part to enable Standby
 bool DummyWallbox::SetStandbyEnabled(bool standbyEnabled)
 {
     if (mStandbyEnabled != standbyEnabled)
@@ -93,7 +92,6 @@ bool DummyWallbox::GetStandbyEnabled()
     Logger::Debug("Dummy wallbox: returning standby enabled = %d", mStandbyEnabled);
     return mStandbyEnabled;
 }
-
 
 float DummyWallbox::GetChargingCurrentLimit()
 {

--- a/src/Components/Wallbox/DummyWallbox.cpp
+++ b/src/Components/Wallbox/DummyWallbox.cpp
@@ -75,6 +75,30 @@ bool DummyWallbox::IsChargingEnabled()
     return mChargingEnabled;
 }
 
+bool DummyWallbox::SetStandbyEnabled(bool standbyEnabled)
+{
+    bool ok = true;
+
+    if (!mStandbyEnabled && standbyEnabled)
+    {
+        Logger::Info("Dummy wallbox: enabling standby");
+        mStandbyEnabled = true;
+    }
+    else if (mStandbyEnabled && !standbyEnabled)
+    {
+        Logger::Info("Dummy wallbox: disabling standby");
+        mStandbyEnabled = false;
+    }
+
+    return ok;
+}
+
+bool DummyWallbox::IsStandbyEnabled()
+{
+    Logger::Debug("Dummy wallbox: returning standby enabled %i", mStandbyEnabled);
+    return mStandbyEnabled;
+}
+
 float DummyWallbox::GetChargingCurrentLimit()
 {
     Logger::Debug("Dummy wallbox: returning charging current limit %f A", mChargingCurrentLimitA);

--- a/src/Components/Wallbox/DummyWallbox.cpp
+++ b/src/Components/Wallbox/DummyWallbox.cpp
@@ -75,29 +75,25 @@ bool DummyWallbox::IsChargingEnabled()
     return mChargingEnabled;
 }
 
+//New Part to enable Standby
 bool DummyWallbox::SetStandbyEnabled(bool standbyEnabled)
 {
-    bool ok = true;
-
-    if (!mStandbyEnabled && standbyEnabled)
+    if (mStandbyEnabled != standbyEnabled)
     {
-        Logger::Info("Dummy wallbox: enabling standby");
-        mStandbyEnabled = true;
-    }
-    else if (mStandbyEnabled && !standbyEnabled)
-    {
-        Logger::Info("Dummy wallbox: disabling standby");
-        mStandbyEnabled = false;
+        Logger::Info("Dummy wallbox: %s standby",
+                     standbyEnabled ? "enabling" : "disabling");
     }
 
-    return ok;
+    mStandbyEnabled = standbyEnabled;
+    return true;
 }
 
-bool DummyWallbox::IsStandbyEnabled()
+bool DummyWallbox::GetStandbyEnabled()
 {
-    Logger::Debug("Dummy wallbox: returning standby enabled %i", mStandbyEnabled);
+    Logger::Debug("Dummy wallbox: returning standby enabled = %d", mStandbyEnabled);
     return mStandbyEnabled;
 }
+
 
 float DummyWallbox::GetChargingCurrentLimit()
 {

--- a/src/Components/Wallbox/DummyWallbox.h
+++ b/src/Components/Wallbox/DummyWallbox.h
@@ -34,6 +34,6 @@ private:
     float mFailsafeCurrentA{Constants::DummyWallbox::FailSafeCurrentA};
     float mEnergyMeterWh{0.0f};
     bool mChargingEnabled{true};
-    bool mStandbyEnabled{true}; // default: standby enabled
+    bool mStandbyEnabled{false};
     float mPreviousChargingCurrentLimitA{Constants::HeidelbergWallbox::InitialChargingCurrentLimitA};
 };

--- a/src/Components/Wallbox/DummyWallbox.h
+++ b/src/Components/Wallbox/DummyWallbox.h
@@ -16,6 +16,7 @@ public:
     virtual VehicleState GetState() override;
     virtual bool SetChargingCurrentLimit(float currentLimitA) override;
     virtual bool SetChargingEnabled(bool chargingEnabled) override;
+    virtual bool SetStandbyEnabled(bool standbyEnabled) override;
     virtual float GetChargingCurrentLimit() override;
     virtual float GetEnergyMeterValue() override;
     virtual float GetFailsafeCurrent() override;
@@ -24,6 +25,8 @@ public:
     virtual bool GetChargingCurrents(float &c1A, float &c2A, float &c3A) override;
     virtual bool GetChargingVoltages(float &v1V, float &v2V, float &v3V) override;
     virtual bool IsChargingEnabled() override;
+    virtual bool IsStandbyEnabled() override;
+
 #pragma endregion IWallbox
 
 private:
@@ -31,5 +34,6 @@ private:
     float mFailsafeCurrentA{Constants::DummyWallbox::FailSafeCurrentA};
     float mEnergyMeterWh{0.0f};
     bool mChargingEnabled{true};
+    bool mStandbyEnabled{true}; // default: standby enabled
     float mPreviousChargingCurrentLimitA{Constants::HeidelbergWallbox::InitialChargingCurrentLimitA};
 };

--- a/src/Components/Wallbox/DummyWallbox.h
+++ b/src/Components/Wallbox/DummyWallbox.h
@@ -25,7 +25,7 @@ public:
     virtual bool GetChargingCurrents(float &c1A, float &c2A, float &c3A) override;
     virtual bool GetChargingVoltages(float &v1V, float &v2V, float &v3V) override;
     virtual bool IsChargingEnabled() override;
-    virtual bool IsStandbyEnabled() override;
+    virtual bool GetStandbyEnabled() override;
 
 #pragma endregion IWallbox
 

--- a/src/Components/Wallbox/HeidelbergWallbox.cpp
+++ b/src/Components/Wallbox/HeidelbergWallbox.cpp
@@ -145,19 +145,19 @@ bool HeidelbergWallbox::SetStandbyEnabled(bool standbyEnabled)
 
 bool HeidelbergWallbox::GetStandbyEnabled()
 {
-    uint16_t reg[1];
+    uint16_t registerValue[1];
 
     if (!ModbusRTU::Instance()->ReadRegisters(
             Constants::HeidelbergRegisters::DisableStandby,
             1,
             0x3,
-            reg))
+            registerValue))
     {
         Logger::Error("Heidelberg wallbox: Could not read standby state");
         return mStandbyEnabled; // last known
     }
 
-    bool enabled = (reg[0] == 0); // 0 = standby allowed
+    bool enabled = (registerValue[0] == 0); // 0 = standby allowed
     mStandbyEnabled = enabled;
 
     Logger::Debug("Heidelberg wallbox: Read standby enabled = %d", enabled);

--- a/src/Components/Wallbox/HeidelbergWallbox.cpp
+++ b/src/Components/Wallbox/HeidelbergWallbox.cpp
@@ -28,7 +28,7 @@ void HeidelbergWallbox::Init()
         // Error writing modbus register
         Logger::Error("ERROR: Could not configure standby");
     }
-    
+
     // Disable watchdog
     Logger::Debug("Heidelberg wallbox: Setting watch dog timeout to %d s", Constants::HeidelbergWallbox::WatchdogTimeoutS);
     if (!ModbusRTU::Instance()->WriteHoldRegister16(Constants::HeidelbergRegisters::WatchdogTimeout, Constants::HeidelbergWallbox::WatchdogTimeoutS))
@@ -119,7 +119,6 @@ bool HeidelbergWallbox::IsChargingEnabled()
     return mChargingEnabled;
 }
 
-//New Part to enable Standby
 bool HeidelbergWallbox::SetStandbyEnabled(bool standbyEnabled)
 {
     bool ok = true;
@@ -136,7 +135,9 @@ bool HeidelbergWallbox::SetStandbyEnabled(bool standbyEnabled)
             Constants::HeidelbergRegisters::DisableStandby, value);
 
         if (ok)
+        {
             mStandbyEnabled = standbyEnabled;
+        }
     }
 
     return ok;

--- a/src/Components/Wallbox/HeidelbergWallbox.h
+++ b/src/Components/Wallbox/HeidelbergWallbox.h
@@ -6,7 +6,7 @@
 class HeidelbergWallbox : public IWallbox
 {
 private:
-    HeidelbergWallbox(){};
+    HeidelbergWallbox() {};
 
 public:
     static HeidelbergWallbox *Instance();
@@ -26,7 +26,7 @@ public:
     virtual bool GetChargingVoltages(float &v1V, float &v2V, float &v3V) override;
     virtual bool IsChargingEnabled() override;
     virtual bool GetStandbyEnabled() override;
-    
+
 #pragma endregion IWallbox
 
 private:

--- a/src/Components/Wallbox/HeidelbergWallbox.h
+++ b/src/Components/Wallbox/HeidelbergWallbox.h
@@ -16,6 +16,7 @@ public:
     virtual VehicleState GetState() override;
     virtual bool SetChargingCurrentLimit(float currentLimitA) override;
     virtual bool SetChargingEnabled(bool chargingEnabled) override;
+    virtual bool SetStandbyEnabled(bool standbyEnabled) override;
     virtual float GetChargingCurrentLimit() override;
     virtual float GetEnergyMeterValue() override;
     virtual float GetFailsafeCurrent() override;
@@ -24,6 +25,8 @@ public:
     virtual bool GetChargingCurrents(float &c1A, float &c2A, float &c3A) override;
     virtual bool GetChargingVoltages(float &v1V, float &v2V, float &v3V) override;
     virtual bool IsChargingEnabled() override;
+    virtual bool IsStandbyEnabled() override;
+    
 #pragma endregion IWallbox
 
 private:
@@ -33,5 +36,6 @@ private:
     float mLastPowerMeterValueW{0.0f};
     float mLastEnergyMeterValueWh{0.0f};
     bool mChargingEnabled{true};
+    bool mStandbyEnabled{true}; // default: standby enabled
     float mPreviousChargingCurrentLimitA{Constants::HeidelbergWallbox::InitialChargingCurrentLimitA};
 };

--- a/src/Components/Wallbox/HeidelbergWallbox.h
+++ b/src/Components/Wallbox/HeidelbergWallbox.h
@@ -25,7 +25,7 @@ public:
     virtual bool GetChargingCurrents(float &c1A, float &c2A, float &c3A) override;
     virtual bool GetChargingVoltages(float &v1V, float &v2V, float &v3V) override;
     virtual bool IsChargingEnabled() override;
-    virtual bool IsStandbyEnabled() override;
+    virtual bool GetStandbyEnabled() override;
     
 #pragma endregion IWallbox
 

--- a/src/Components/Wallbox/IWallbox.h
+++ b/src/Components/Wallbox/IWallbox.h
@@ -57,6 +57,6 @@ public:
     virtual bool SetStandbyEnabled(bool standbyEnabled) = 0;
     
     // Returns if Standby is currently enabled
-    virtual bool IsStandbyEnabled() = 0;
+    virtual bool GetStandbyEnabled() = 0;
 
 };

--- a/src/Components/Wallbox/IWallbox.h
+++ b/src/Components/Wallbox/IWallbox.h
@@ -52,4 +52,11 @@ public:
 
     // Enables/disables the charging
     virtual bool SetChargingEnabled(bool chargingEnabled) = 0;
+
+    // Enables/disables standby
+    virtual bool SetStandbyEnabled(bool standbyEnabled) = 0;
+    
+    // Returns if Standby is currently enabled
+    virtual bool IsStandbyEnabled() = 0;
+
 };


### PR DESCRIPTION
Created a new MQTT topic /standby_enabled to control the Standby register of the Heidelberg Wallbox. The topic is automatically discovered by Home Assistant.

Tested successfully on the LILYGO build:
- MQTT topic HeidelBridge/standby_enabled is published correctly.
- Home Assistant controls added.
- Standby mode can be set via Home Assistant → Wallbox enters deep standby after ~10-15 minutes.
- Wakeup via Heidelberg interface is not possible while in deep standby.
- Wallbox wakes up automatically when a car is connected, and control via Home Assistant/MQTT is restored.
- Disabling Standby also works.

EVCC will not work if Wallbox is in deep standby.